### PR TITLE
Add Support for Waveshare ESP32-S3-LCD-1.47 board

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -93,14 +93,7 @@ lib_deps_core =
 	ayushsharma82/ElegantOTA@3.1.0
 
 [env:LILYGO-T-Dongle-S3]
-platform = ${common.platform}
-platform_packages = ${common.platform_packages}
-framework = ${common.framework}
-extra_scripts = ${common.extra_scripts}
-monitor_filters = ${common.monitor_filters}
-build_src_filter = ${common.build_src_filter}
-build_unflags = ${common.build_unflags}
-
+extends = common
 board = esp32-s3-devkitc-1
 board_build.flash_size = 16MB
 board_build.partitions = default_8MB.csv
@@ -112,20 +105,8 @@ build_flags =
 	-D USE_SD_MMC_INTERFACE ; ESP32 Maurader
 	-D GENERIC_ESP32 ; ESP32 Maurader
 	-D CONFIG_ASYNC_TCP_QUEUE_SIZE=128
-	; Button config
-	-D BTN_PIN=0
-	; LED config
-	-D NUM_LEDS=1
-	-D LED_DI_PIN=40
-	-D LED_CI_PIN=39
-	; SD port config
-	-D SD_MMC_D0_PIN=14
-	-D SD_MMC_D1_PIN=17
-	-D SD_MMC_D2_PIN=21
-	-D SD_MMC_D3_PIN=18
-	-D SD_MMC_CLK_PIN=12
-	-D SD_MMC_CMD_PIN=16
-	; Display (ST7735s) hardware configuration:
+;;;;;;;; Pin Config for TFT ;;;;;;;;
+	-D PANEL_TYPE=lgfx::Panel_ST7735S ; Full list here: https://github.com/lovyan03/LovyanGFX/tree/master/src/lgfx/v1/panel
 	-D DISPLAY_RST=1
 	-D DISPLAY_DC=2
 	-D DISPLAY_MOSI=3
@@ -138,7 +119,19 @@ build_flags =
 	-D DISPLAY_HEIGHT=80
 	-D TFT_WIDTH=80
 	-D TFT_HEIGHT=160
-
+;;;;;;;; Pin Config for SD ;;;;;;;;
+	-D SD_MMC_D0_PIN=14
+	-D SD_MMC_D1_PIN=17
+	-D SD_MMC_D2_PIN=21
+	-D SD_MMC_D3_PIN=18
+	-D SD_MMC_CLK_PIN=12
+	-D SD_MMC_CMD_PIN=16
+;;;;;;;; Pin Config for Status LED and Button ;;;;;;;;
+	-D BTN_PIN=0
+	-D NUM_LEDS=1
+	-D LED_DI_PIN=40
+	-D LED_CI_PIN=39
+;;;;;;;; End of Pin Config ;;;;;;;;
 lib_deps = 
     ${common.lib_deps_core}
 	h2zero/NimBLE-Arduino@^1.4.2 ; ESP32 Maurader
@@ -147,15 +140,55 @@ lib_deps =
 	lovyan03/LovyanGFX@^1.1.16
 	https://github.com/pololu/apa102-arduino
 
-[env:Generic-ESP32-S2]
-platform = ${common.platform}
-platform_packages = ${common.platform_packages}
-framework = ${common.framework}
-extra_scripts = ${common.extra_scripts}
-monitor_filters = ${common.monitor_filters}
-build_src_filter = ${common.build_src_filter}
-build_unflags = ${common.build_unflags}
+[env:Waveshare-ESP32-S3-LCD-1_47]
+extends = common
+board = esp32-s3-devkitc-1
+board_build.flash_size = 16MB
+board_build.partitions = default_8MB.csv
+build_flags = 
+	${common.build_flags}
+	-D ARDUINO_ARCH_ESP32S3
+	-D HAS_SD ; ESP32 Maurader
+	-D USE_SD_MMC_INTERFACE ; ESP32 Maurader
+	-D GENERIC_ESP32 ; ESP32 Maurader
+	-D CONFIG_ASYNC_TCP_QUEUE_SIZE=128
+	-DBOARD_HAS_PSRAM
+;;;;;;;; Pin Config for TFT ;;;;;;;;
+	-D PANEL_TYPE=lgfx::Panel_ST7789 ; Full list here: https://github.com/lovyan03/LovyanGFX/tree/master/src/lgfx/v1/panel
+	-D DISPLAY_RST=39
+	-D DISPLAY_DC=41
+	-D DISPLAY_MOSI=45
+	-D DISPLAY_CS=42
+	-D DISPLAY_SCLK=40
+	-D DISPLAY_LEDA=48
+	-D DISPLAY_MISO=-1
+	-D DISPLAY_BUSY=-1
+	-D DISPLAY_WIDTH=320
+	-D DISPLAY_HEIGHT=172
+	-D TFT_WIDTH=172
+	-D TFT_HEIGHT=320
+;;;;;;;;Pin Config for SD;;;;;;;;
+	-D SD_MMC_D0_PIN=16
+	-D SD_MMC_D1_PIN=18
+	-D SD_MMC_D2_PIN=17
+	-D SD_MMC_D3_PIN=21
+	-D SD_MMC_CLK_PIN=14
+	-D SD_MMC_CMD_PIN=15
+;;;;;;;;Pin Config for Status LED and Button;;;;;;;;
+	-D BTN_PIN=0
+	-D NUM_LEDS=1
+	-D LED_DI_PIN=38
+	-D LED_CI_PIN=38
+;;;;;;;; End of Pin Config ;;;;;;;;
+lib_deps = 
+	${common.lib_deps_core}
+	mathertel/OneButton
+	bitbank2/PNGdec@^1.0.1
+	lovyan03/LovyanGFX@^1.1.16
+	https://github.com/pololu/apa102-arduino
 
+[env:Generic-ESP32-S2]
+extends = common
 board = esp32-s2-kaluga-1 ; close enough
 board_build.partitions = min_spiffs.csv
 monitor_speed = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -182,6 +182,7 @@ build_flags =
 ;;;;;;;; End of Pin Config ;;;;;;;;
 lib_deps = 
 	${common.lib_deps_core}
+	h2zero/NimBLE-Arduino@^1.4.2 ; ESP32 Maurader
 	mathertel/OneButton
 	bitbank2/PNGdec@^1.0.1
 	lovyan03/LovyanGFX@^1.1.16

--- a/src/Devices/TFT/HardwareTFT.cpp
+++ b/src/Devices/TFT/HardwareTFT.cpp
@@ -10,7 +10,7 @@
 
 class LGFX_LiLyGo_TDongleS3 : public lgfx::LGFX_Device
 {
-    lgfx::Panel_ST7735S _panel_instance;
+    PANEL_TYPE _panel_instance; // PANEL_TYPE defined in platformio.ini file
     lgfx::Bus_SPI _bus_instance;
     lgfx::Light_PWM _light_instance;
 


### PR DESCRIPTION
Hi! Thank you for your hard work on this awesome project.

This PR adds support for the [Waveshare ESP32-S3-LCD-1.47](https://www.waveshare.com/esp32-s3-lcd-1.47.htm), a board very similar to the LILYGO Dongle.

Additionally, it [changes the `platformio.ini` configuration to use `extends = common`](https://github.com/kylefmohr/USBArmyKnife/blob/1ff6d60ee35bcaad01cf975b7c3d30e0f74b57a7/platformio.ini#L96), rather than redundantly listing the `${common.<whatever>}` options for each board.

Finally, it [moves the definition](https://github.com/kylefmohr/USBArmyKnife/blob/1ff6d60ee35bcaad01cf975b7c3d30e0f74b57a7/src/Devices/TFT/HardwareTFT.cpp#L13) of the TFT panel type [to the `platformio.ini` file](https://github.com/kylefmohr/USBArmyKnife/blob/1ff6d60ee35bcaad01cf975b7c3d30e0f74b57a7/platformio.ini#L109)

These changes have been tested on the aforementioned Waveshare board. Thanks again!