### PR TITLE
rickroll example better compatibility

### DIFF
--- a/examples/rickroll/autorun.ds
+++ b/examples/rickroll/autorun.ds
@@ -1,4 +1,4 @@
-GUI
+GUI r
 DELAY 1000
 STRING https://www.youtube.com/watch?v=xvFZjo5PgG0
 DELAY 1000


### PR DESCRIPTION
Using GUI r to open the run menu seems to work better at launching the web browser and auto-playing the video than just "GUI" alone.