### PR TITLE
Resolve long standing USB issue where the USB isnt seen by the host

### DIFF
--- a/src/Devices/USB/USBCore.cpp
+++ b/src/Devices/USB/USBCore.cpp
@@ -163,7 +163,7 @@ void USBCore::begin(Preferences &prefs)
     TinyUSBDevice.setVersion(version);
 
     const uint16_t deviceVersion = prefs.getUShort(USB_DeviceVersion, USB_DeviceVersion_Default);
-    TinyUSBDevice.setVersion(deviceVersion);
+    TinyUSBDevice.setDeviceVersion(deviceVersion);
 
     const String manufacturerArdString = prefs.getString(USB_DeviceManufacturer, USB_DeviceManufacturer_Default);
     manufacturer = std::string(manufacturerArdString.c_str());
@@ -173,22 +173,40 @@ void USBCore::begin(Preferences &prefs)
     product = std::string(productArdString.c_str());
     TinyUSBDevice.setProductDescriptor(product.c_str());
   }
+
+  // now all our descriptors are set up we can now begin allowing the host OS to
+  // talk to us
+  tud_connect();
+
+  // we now wait up to a second for the host to 'mount' us
+  // we might not even be connected to a USB device (battery) so don't want too long
+  for (uint8_t counter = 0; counter < 10 && (!TinyUSBDevice.ready() || !TinyUSBDevice.mounted()); ++counter)
+  {
+    delay(100);
+  }
+
+  if (!TinyUSBDevice.ready() || !TinyUSBDevice.mounted())
+  {
+    Debug::Log.error(LOG_USB, "Timeout waiting for USB to mount");
+  }
 }
 
 void USBCore::reset()
 {
-  if (TinyUSBDevice.ready() && TinyUSBDevice.mounted())
+  if (!TinyUSBDevice.ready())
   {
-    Debug::Log.info(LOG_USB, "USB reset");
+    Debug::Log.error(LOG_USB, "USB not ready, continuing");
+  }
 
-    tud_disconnect();
-    delay(250);
-    tud_connect();
-  }
-  else
+  if (!TinyUSBDevice.mounted())
   {
-    Debug::Log.info(LOG_USB, "USB not ready or not mounted");
+    Debug::Log.error(LOG_USB, "USB not mounted, continuing");
   }
+
+  tud_disconnect();
+  delay(250);
+  tud_connect();
+  Debug::Log.info(LOG_USB, "USB reset");
 }
 
 void USBCore::loop(Preferences &prefs)

--- a/src/Devices/USB/USBHID.cpp
+++ b/src/Devices/USB/USBHID.cpp
@@ -56,13 +56,6 @@ void USBHID::begin(Preferences &prefs)
         usb_hid->setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));
         usb_hid->setStringDescriptor("HID Composite");
         usb_hid->begin();
-
-        if (TinyUSBDevice.mounted())
-        {
-            TinyUSBDevice.detach();
-            delay(10);
-            TinyUSBDevice.attach();
-        }
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,11 @@ static void displayMessage(const char* heading, const char* value = nullptr, boo
 
 void setup()
 {
+  // first thing, tear USB down. We don't know what state the
+  // boot loader could have been left it in. Stop responding and the host OS should
+  // forget about us and tear down
+  tud_disconnect();
+
   prefs.begin("usbarmyknife");
 
   // First set up our core components / hw


### PR DESCRIPTION
This *I think* fixes a long standing issue where the USB stack doesn't come up on some machine.

I think this is due to the transition from bootloader mode (where CDC is enabled) and TinyUSB and the host caching the bootloaders set up.

My fix:
* When we start tear down USB gpio
* do the TinyUSB init
* re-enable PHY USB gpio