### PR TITLE
Add tftTextSize setting and DISPLAY_SET_TEXT_SIZE Ducky script command.

### DIFF
--- a/src/Attacks/Ducky/Extensions.h
+++ b/src/Attacks/Ducky/Extensions.h
@@ -115,6 +115,15 @@ static int handleDisplayText(const std::string &str, const std::unordered_map<st
     return true;
 }
 
+static int handleSetTextSize(const std::string &str, const std::unordered_map<std::string, std::string> &constants, const std::unordered_map<std::string, int> &variables)
+{
+    std::string arg = str.substr(str.find(' ') + 1);
+    int textSize = asciiOrVariableToInt(arg, variables);
+    Devices::TFT.setTextSize(textSize);
+    return true;
+}
+
+
 static int handleUSBMode(const std::string &str, const std::unordered_map<std::string, std::string> &constants, const std::unordered_map<std::string, int> &variables)
 {
     bool mountAsCdrom = startsWith(str, "USB_MOUNT_CDROM_READ_ONLY");
@@ -838,6 +847,7 @@ void addDuckyScriptExtensions(
     extCommands["DISPLAY_CLEAR"] = handleDisplayClear;
     extCommands["LED"] = handleLED;
     extCommands["LED_B"] = handleLEDBlue;
+    extCommands["SET_TEXT_SIZE"] = handleSetTextSize;
 
     // touch
     extCommands["WAIT_FOR_TOUCH"] = waitForTouch;

--- a/src/Attacks/Ducky/Extensions.h
+++ b/src/Attacks/Ducky/Extensions.h
@@ -115,7 +115,7 @@ static int handleDisplayText(const std::string &str, const std::unordered_map<st
     return true;
 }
 
-static int handleSetTextSize(const std::string &str, const std::unordered_map<std::string, std::string> &constants, const std::unordered_map<std::string, int> &variables)
+static int handleDisplaySetTextSize(const std::string &str, const std::unordered_map<std::string, std::string> &constants, const std::unordered_map<std::string, int> &variables)
 {
     std::string arg = str.substr(str.find(' ') + 1);
     int textSize = asciiOrVariableToInt(arg, variables);
@@ -845,9 +845,9 @@ void addDuckyScriptExtensions(
     extCommands["DISPLAY_PNG"] = handleDisplayPNG;
     extCommands["DISPLAY_TEXT"] = handleDisplayText;
     extCommands["DISPLAY_CLEAR"] = handleDisplayClear;
+    extCommands["DISPLAY_SET_TEXT_SIZE"] = handleDisplaySetTextSize;
     extCommands["LED"] = handleLED;
     extCommands["LED_B"] = handleLEDBlue;
-    extCommands["SET_TEXT_SIZE"] = handleSetTextSize;
 
     // touch
     extCommands["WAIT_FOR_TOUCH"] = waitForTouch;

--- a/src/Attacks/Ducky/Extensions.h
+++ b/src/Attacks/Ducky/Extensions.h
@@ -117,8 +117,8 @@ static int handleDisplayText(const std::string &str, const std::unordered_map<st
 
 static int handleDisplaySetTextSize(const std::string &str, const std::unordered_map<std::string, std::string> &constants, const std::unordered_map<std::string, int> &variables)
 {
-    std::string arg = str.substr(str.find(' ') + 1);
-    int textSize = asciiOrVariableToInt(arg, variables);
+    const std::string arg = str.substr(str.find(' ') + 1);
+    const int textSize = asciiOrVariableToInt(arg, variables);
     Devices::TFT.setTextSize(textSize);
     return true;
 }

--- a/src/Devices/TFT/HardwareTFT.cpp
+++ b/src/Devices/TFT/HardwareTFT.cpp
@@ -276,6 +276,11 @@ void HardwareTFT::setTextSize(int size)
     lcd.setTextSize(textSize);
 }
 
+int HardwareTFT::getTextSize()
+{
+    return  static_cast<int>(std::round(lcd.getTextSizeX() * 10)) ;
+}
+
 HardwareTFT::HardwareTFT()
 {
 }

--- a/src/Devices/TFT/HardwareTFT.cpp
+++ b/src/Devices/TFT/HardwareTFT.cpp
@@ -270,15 +270,15 @@ int HardwareTFT::convertStringToColor(const std::string &color)
     return lcd.color24to16(value);
 }
 
-void HardwareTFT::setTextSize(int size)
+void HardwareTFT::setTextSize(const int size)
 {
-    float textSize = (float) size / 10.0 ;
+    const float textSize = (float) size / 10.0;
     lcd.setTextSize(textSize);
 }
 
 int HardwareTFT::getTextSize()
 {
-    return  static_cast<int>(std::round(lcd.getTextSizeX() * 10)) ;
+    return  static_cast<int>(std::round(lcd.getTextSizeX() * 10));
 }
 
 HardwareTFT::HardwareTFT()

--- a/src/Devices/TFT/HardwareTFT.cpp
+++ b/src/Devices/TFT/HardwareTFT.cpp
@@ -9,6 +9,10 @@
 #include <unordered_map>
 
 #define LOG_TFT "TFT"
+
+#define TFT_TextSize "tftTextSize"
+#define TFT_TextSize_Default 10
+
 #define MAX_RADIUS 4
 static uint8_t heatBeatRadius = MAX_RADIUS;
 static int heatBeatColor = TFT_WHITE;
@@ -266,6 +270,12 @@ int HardwareTFT::convertStringToColor(const std::string &color)
     return lcd.color24to16(value);
 }
 
+void HardwareTFT::setTextSize(int size)
+{
+    float textSize = (float) size / 10.0 ;
+    lcd.setTextSize(textSize);
+}
+
 HardwareTFT::HardwareTFT()
 {
 }
@@ -300,11 +310,13 @@ void HardwareTFT::loop(Preferences &prefs)
 
 void HardwareTFT::begin(Preferences &prefs)
 {
+    registerUserConfigurableSetting(CATEGORY_TFT, TFT_TextSize, USBArmyKnifeCapability::SettingType::Int16, (int16_t)TFT_TextSize_Default);
+    float textSize = (float)prefs.getShort(TFT_TextSize, TFT_TextSize_Default) / (float)10.0;
     lcd.init();
     lcd.setBrightness(128);
     lcd.clear(backgroundColor);
     lcd.display();
-
+    lcd.setTextSize(textSize);
     Attacks::Ducky.registerDynamicVariable([this]()
                                            { return std::pair("#_DISPLAY_WIDTH_", std::to_string(DISPLAY_WIDTH)); });
     Attacks::Ducky.registerDynamicVariable([this]()

--- a/src/Devices/TFT/HardwareTFT.h
+++ b/src/Devices/TFT/HardwareTFT.h
@@ -16,6 +16,7 @@ public:
   void displayRectangle(const int& x, const int& y, const int& width, const int& height);
   void setForegroundColor(int color);
   void setBackgroundColor(int color);
+  void setTextSize(int size);
   int convertStringToColor(const std::string& color);
   void clearScreen();
   void powerOff();

--- a/src/Devices/TFT/HardwareTFT.h
+++ b/src/Devices/TFT/HardwareTFT.h
@@ -17,6 +17,7 @@ public:
   void setForegroundColor(int color);
   void setBackgroundColor(int color);
   void setTextSize(int size);
+  int getTextSize();
   int convertStringToColor(const std::string& color);
   void clearScreen();
   void powerOff();

--- a/src/Devices/TFT/NoHardwareTFT.cpp
+++ b/src/Devices/TFT/NoHardwareTFT.cpp
@@ -54,7 +54,7 @@ void HardwareTFT::setTextSize(int size)
 
 int HardwareTFT::getTextSize()
 {
-    return  10 ;
+    return  10;
 }
 
 HardwareTFT::HardwareTFT()

--- a/src/Devices/TFT/NoHardwareTFT.cpp
+++ b/src/Devices/TFT/NoHardwareTFT.cpp
@@ -47,6 +47,16 @@ int HardwareTFT::convertStringToColor(const std::string& color)
     return -1;
 }
 
+void HardwareTFT::setTextSize(int size)
+{
+
+}
+
+int HardwareTFT::getTextSize()
+{
+    return  10 ;
+}
+
 HardwareTFT::HardwareTFT()
 {
 }

--- a/src/USBArmyKnifeCapability.h
+++ b/src/USBArmyKnifeCapability.h
@@ -4,6 +4,7 @@
 
 #define CATEGORY_USB 1
 #define CATEGORY_WIFI 2
+#define CATEGORY_TFT 3
 
 class USBArmyKnifeCapability
 {

--- a/src/Utilities/Format.cpp
+++ b/src/Utilities/Format.cpp
@@ -7,6 +7,7 @@
 #include "../Debug/Logging.h"
 
 static bool running = false;
+static float scale = 1.0 ;
 
 #if defined(ARDUINO_ARCH_ESP32) && defined(DISPLAY_WIDTH)
 void FormatStatusUpdateTask(void *arg)
@@ -17,20 +18,20 @@ void FormatStatusUpdateTask(void *arg)
     int count = 0;
     Devices::TFT.clearScreen();
     Devices::TFT.display(0, 0, line1);
-    Devices::TFT.display(0, 10, line2);
+    Devices::TFT.display(0, 10 * scale, line2);
 
     while (running)
     {
         vTaskDelay(pdMS_TO_TICKS(1500));
         Devices::LED.changeLEDState(count % 2 == 0, 24, 100, 100, 255);
-        Devices::TFT.display(count, 20, ".");
+        Devices::TFT.display(count, 20 * scale, ".");
         count++;
 
         if (count >= DISPLAY_WIDTH -1)
         {
             Devices::TFT.clearScreen();
             Devices::TFT.display(0, 0, line1);
-            Devices::TFT.display(0, 10, line2);
+            Devices::TFT.display(0, 10 * scale, line2);
             count = 0;
         }
     }
@@ -48,16 +49,17 @@ void FormatStatusUpdateTask(void *arg)
 #ifdef DISPLAY_WIDTH
 void AskFormatSD(Preferences &prefs)
 {
+    scale = Devices::TFT.getTextSize() / 10.0 ;
     // Display a message when the SD card cannot be found. Some devices are very picky about the
     // make and model of SD card they support, if you are debugging and are reading this try another card
     // and format with 1 FAT32 partition <32gb
     Devices::TFT.display(0, 0, "Error: Valid SD not found");
 
-    Devices::TFT.display(0, 20, "Hold button to attempt");
-    Devices::TFT.display(0, 30, "to format the SD card.");
+    Devices::TFT.display(0, 20 * scale, "Hold button to attempt");
+    Devices::TFT.display(0, 30 * scale, "to format the SD card.");
 
-    Devices::TFT.display(0, 50, "Note: the drive will not");
-    Devices::TFT.display(0, 60, "be readable on Windows");
+    Devices::TFT.display(0, 50 * scale, "Note: the drive will not");
+    Devices::TFT.display(0, 60 * scale, "be readable on Windows");
 
     // we don't want people using the web interface if the SD card is bad
     Devices::WiFi.end();

--- a/src/Utilities/Settings.cpp
+++ b/src/Utilities/Settings.cpp
@@ -187,6 +187,9 @@ void enumerateSettingsAsJson(Preferences &prefs, JsonArray array)
         case CATEGORY_WIFI:
             categoryObj["name"] = "WIFI";
             break;
+        case CATEGORY_TFT:
+            categoryObj["name"] = "TFT";
+            break;
         default:
             categoryObj["name"] = "UNKNOWN";
             break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,14 +40,18 @@ static void displayMessage(const char* heading, const char* value = nullptr, boo
   const auto WHITE = Devices::TFT.convertStringToColor("WHITE");
   const auto LIGHTGREY = Devices::TFT.convertStringToColor("LIGHTGREY");
   const auto RED = Devices::TFT.convertStringToColor("RED");
-
+  float scale = Devices::TFT.getTextSize() / 10.0; 
+  
   Devices::TFT.setForegroundColor(LIGHTGREY);
-  Devices::TFT.display(0, currentLine * 8, heading);
+  Devices::TFT.display(0, static_cast<int>(std::round(currentLine * 8 * scale)), heading);
 
   if (value != nullptr)
   {
     Devices::TFT.setForegroundColor(warning ? RED : WHITE);
-    Devices::TFT.display((strlen(heading) + 1) * 6, currentLine * 8, value);
+    Devices::TFT.display( static_cast<int>(std::round((strlen(heading) + 1) * 6 * scale)),
+                          static_cast<int>(std::round(currentLine * 8 * scale)),
+                          value
+                        );
   }
 
   Devices::TFT.setForegroundColor(WHITE);


### PR DESCRIPTION
This PR adds functionality to change the text size on the TFT screen.

I find the text barely readable with the default settings on the waveshare ESP32-S3-LCD-1.47, which is why I implemented this.

The following are implemented:

- Preference setting `tftTextSize`, uint16, default value = 10. This allows to change the text size at boot time.
- Ducky script command `SET_TEXT_SIZE`, allowing to change the text size while executing a Ducky script.

For both, the expected argument is an int, which value divided by 10 will be the new font size, given as parameter to `setTextSize()` from lgfx.
So giving an argument of 20 will double the font size compared to the default.