### PR TITLE
Fix LED Colors

### DIFF
--- a/src/Attacks/Ducky/Extensions.h
+++ b/src/Attacks/Ducky/Extensions.h
@@ -181,8 +181,7 @@ static int handleLED(const std::string &str, const std::unordered_map<std::strin
 
 static int handleLEDBlue(const std::string &str, const std::unordered_map<std::string, std::string> &constants, const std::unordered_map<std::string, int> &variables)
 {
-    /* Blue is 160: https://github.com/FastLED/FastLED/wiki/FastLED-HSV-Colors */
-    Devices::LED.changeLEDState(true, 160, 100, 100, 255);
+    Devices::LED.setLEDBlue(255);
     return true;
 }
 

--- a/src/Attacks/Ducky/Extensions.h
+++ b/src/Attacks/Ducky/Extensions.h
@@ -181,7 +181,8 @@ static int handleLED(const std::string &str, const std::unordered_map<std::strin
 
 static int handleLEDBlue(const std::string &str, const std::unordered_map<std::string, std::string> &constants, const std::unordered_map<std::string, int> &variables)
 {
-    Devices::LED.changeLEDState(true, 240, 100, 100, 255);
+    /* Blue is 160: https://github.com/FastLED/FastLED/wiki/FastLED-HSV-Colors */
+    Devices::LED.changeLEDState(true, 160, 100, 100, 255);
     return true;
 }
 

--- a/src/Devices/LED/APA102/HardwareLED.cpp
+++ b/src/Devices/LED/APA102/HardwareLED.cpp
@@ -58,6 +58,13 @@ void HardwareLED::changeLEDState(bool on, uint8_t hue, uint8_t saturation, uint8
   }
 }
 
+void HardwareLED::setLEDBlue(uint8_t brightness)
+{
+    brightness = (uint8_t) ((float) brightness * (31.f / 255.f));
+    colors[0] = rgb_color(0,0,255);
+    ledStrip.write(colors, 1, brightness);
+}
+
 HardwareLED::HardwareLED()
 {
 }

--- a/src/Devices/LED/FastLED/HardwareLED.cpp
+++ b/src/Devices/LED/FastLED/HardwareLED.cpp
@@ -14,6 +14,7 @@ void HardwareLED::changeLEDState(bool on, uint8_t hue, uint8_t saturation, uint8
 {
   if (on == true)
   {
+#if !defined(WAVESHARE_ESP32_S3_LCD_147)
     // For some reason I need to do colour correction here. I wonder if the CRGB is the wrong byte order?
     if (hue == 0 && saturation == 100 && lum == 100) // red
     {
@@ -27,7 +28,7 @@ void HardwareLED::changeLEDState(bool on, uint8_t hue, uint8_t saturation, uint8
     {
       hue = 160;
     }
-
+#endif
     saturation = map(saturation, 0, 100, 30, 255);
     lum = map(lum, 0, 100, 100, 255);
         
@@ -53,7 +54,11 @@ void HardwareLED::loop(Preferences& prefs)
 
 void HardwareLED::begin(Preferences &prefs)
 {
+#if defined(WAVESHARE_ESP32_S3_LCD_147)
+  FastLED.addLeds<WS2812, LED_DI_PIN, RGB>(leds, NUM_LEDS);
+#else
   FastLED.addLeds<WS2812, LED_DI_PIN>(leds, NUM_LEDS);
+#endif
   FastLED.setBrightness(0);
   FastLED.show();
 }

--- a/src/Devices/LED/FastLED/HardwareLED.cpp
+++ b/src/Devices/LED/FastLED/HardwareLED.cpp
@@ -44,6 +44,13 @@ void HardwareLED::changeLEDState(bool on, uint8_t hue, uint8_t saturation, uint8
   FastLED.show();
 }
 
+void HardwareLED::setLEDBlue(uint8_t brightness)
+{
+  leds[0] = CRGB::Blue;
+  FastLED.setBrightness(brightness);
+  FastLED.show();
+}
+
 HardwareLED::HardwareLED()
 {
 }

--- a/src/Devices/LED/HardwareLED.h
+++ b/src/Devices/LED/HardwareLED.h
@@ -9,6 +9,7 @@ public:
   virtual void loop(Preferences& prefs);
   virtual void begin(Preferences& prefs);
   void changeLEDState(bool on, uint8_t hue, uint8_t saturation, uint8_t lum, uint8_t brightness);
+  void setLEDBlue(uint8_t brightness);
 };
 
 namespace Devices

--- a/src/Devices/LED/NoHardwareLED.cpp
+++ b/src/Devices/LED/NoHardwareLED.cpp
@@ -10,6 +10,10 @@ void HardwareLED::changeLEDState(bool on, uint8_t hue, uint8_t saturation, uint8
 {
 }
 
+void HardwareLED::setLEDBlue(uint8_t brightness)
+{
+}
+
 HardwareLED::HardwareLED()
 {
 }


### PR DESCRIPTION
I had strange LED color behavior: LED_B was giving somewhat pink color, and the sweep_led.ds example showed abrupt color changes for some values.
The changes in this  PR fixed it on my device (Waveshare ESP32-S3 LCD 1.47), by specifying the RGB order in `FastLED.addLeds()`, and removing the specific corrections in `changeLEDState()`.

I have added `#ifdefs` in case this is specific to this device, but I suspect it is more general .
