### PR TITLE
Don't show a crash dump after a normal post-flash reset on ESP32-S3

### DIFF
--- a/src/Devices/Platform/ESP32BoardSupport.cpp
+++ b/src/Devices/Platform/ESP32BoardSupport.cpp
@@ -27,7 +27,10 @@ void ESP32BoardSupport::begin(Preferences &prefs)
 
     backtrace_saver::init();
     const auto &resetReason = esp_reset_reason();
-    hasHadCrash = resetReason != ESP_RST_UNKNOWN && resetReason != ESP_RST_POWERON && resetReason != ESP_RST_SW;
+    // ESP_RST_EXT / ESP_RST_JTAG are produced by a normal post-flash or debugger
+    // reset (e.g. esptool --after hard_reset on ESP32-S3 native USB), not a crash.
+    hasHadCrash = resetReason != ESP_RST_UNKNOWN && resetReason != ESP_RST_POWERON && resetReason != ESP_RST_SW &&
+                  resetReason != ESP_RST_EXT && resetReason != ESP_RST_JTAG;
 }
 
 bool ESP32BoardSupport::hasCrashed()


### PR DESCRIPTION
## Summary
On ESP32-S3 native-USB boards (e.g. the LilyGo T-Dongle-S3), the device shows a **"Crash dump, raise a bug!"** screen on the first boot after a normal flash — even though nothing crashed.

## Cause
`src/Devices/Platform/ESP32BoardSupport.cpp` treats any reset reason other than `ESP_RST_UNKNOWN` / `ESP_RST_POWERON` / `ESP_RST_SW` as a crash:

```cpp
hasHadCrash = resetReason != ESP_RST_UNKNOWN && resetReason != ESP_RST_POWERON && resetReason != ESP_RST_SW;
```

esptool finishes a flash with `--after hard_reset` ("Hard resetting via RTS pin"). On ESP32-S3 native USB that post-flash reset reports as `ESP_RST_EXT` (or `ESP_RST_JTAG`), so the check flags it as a crash → a false crash dump after **every** flash. A full power-cycle (power-on reset) clears it, which is why it's easy to miss when reflashing.

## Fix
Also exclude `ESP_RST_EXT` and `ESP_RST_JTAG` — the reset reasons produced by a normal post-flash / debugger reset — so they aren't reported as a crash.

Both values are defined in the pinned core (`arduino-esp32 3.0.5` / ESP-IDF 5.1) across targets, and the file is wrapped in `#ifdef ARDUINO_ARCH_ESP32`, so the RP2040/Pico build is unaffected.

## Optional follow-up (your call)
If you'd prefer a future-proof version, the check could instead be inverted to a **whitelist of genuine fault resets** (`ESP_RST_PANIC` / `ESP_RST_INT_WDT` / `ESP_RST_TASK_WDT` / `ESP_RST_WDT` / `ESP_RST_BROWNOUT`), which would also cover `ESP_RST_USB`. I kept this PR to the minimal exclusion you suggested in #272 — happy to switch to the whitelist if you'd rather.

Closes #272.
