### PR TITLE
add LILYGO-T-Dongle-S3 without the screen

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -178,6 +178,39 @@ lib_deps =
 	iavorvel/MyLD2410 @ ~1.0.12
 	https://github.com/pololu/apa102-arduino
 
+[env:LILYGO-T-Dongle-S3-No-TFT]
+extends = core-esp32-s3
+board = esp32-s3-devkitc-1
+board_build.flash_size = 16MB
+board_build.partitions = default_8MB.csv
+build_flags = 
+	${core-esp32-s3.build_flags}
+	-D LILYGO_T_DONGLE_S3
+	-D HAS_SD ; ESP32 Maurader
+	-D USE_SD_MMC_INTERFACE ; ESP32 Maurader
+	-D NO_MIC
+	-D NO_TOUCH
+	-D NO_IR
+	-D NO_TFT
+;;;;;;;; Pin Config for SD ;;;;;;;;
+	-D SD_MMC_D0_PIN=14
+	-D SD_MMC_D1_PIN=17
+	-D SD_MMC_D2_PIN=21
+	-D SD_MMC_D3_PIN=18
+	-D SD_MMC_CLK_PIN=12
+	-D SD_MMC_CMD_PIN=16
+;;;;;;;; Pin Config for Status LED and Button ;;;;;;;;
+	-D BTN_PIN=0
+	-D NUM_LEDS=1
+	-D LED_DI_PIN=40
+	-D LED_CI_PIN=39
+;;;;;;;; End of Pin Config ;;;;;;;;
+    ; -D EXT_SENSOR_MOTION_LD2410 ; Uncomment to use the self destruct example
+lib_deps = 
+    ${core-esp32-s3.lib_deps}
+	iavorvel/MyLD2410 @ ~1.0.12
+	https://github.com/pololu/apa102-arduino
+
 [env:Waveshare-ESP32-S3-LCD-1_47]
 extends = core-esp32-s3
 board = esp32-s3-devkitc-1

--- a/platformio.ini
+++ b/platformio.ini
@@ -179,37 +179,10 @@ lib_deps =
 	https://github.com/pololu/apa102-arduino
 
 [env:LILYGO-T-Dongle-S3-No-TFT]
-extends = core-esp32-s3
-board = esp32-s3-devkitc-1
-board_build.flash_size = 16MB
-board_build.partitions = default_8MB.csv
-build_flags = 
-	${core-esp32-s3.build_flags}
-	-D LILYGO_T_DONGLE_S3
-	-D HAS_SD ; ESP32 Maurader
-	-D USE_SD_MMC_INTERFACE ; ESP32 Maurader
-	-D NO_MIC
-	-D NO_TOUCH
-	-D NO_IR
+extends = env:LILYGO-T-Dongle-S3
+build_flags =
+	${env:LILYGO-T-Dongle-S3.build_flags}
 	-D NO_TFT
-;;;;;;;; Pin Config for SD ;;;;;;;;
-	-D SD_MMC_D0_PIN=14
-	-D SD_MMC_D1_PIN=17
-	-D SD_MMC_D2_PIN=21
-	-D SD_MMC_D3_PIN=18
-	-D SD_MMC_CLK_PIN=12
-	-D SD_MMC_CMD_PIN=16
-;;;;;;;; Pin Config for Status LED and Button ;;;;;;;;
-	-D BTN_PIN=0
-	-D NUM_LEDS=1
-	-D LED_DI_PIN=40
-	-D LED_CI_PIN=39
-;;;;;;;; End of Pin Config ;;;;;;;;
-    ; -D EXT_SENSOR_MOTION_LD2410 ; Uncomment to use the self destruct example
-lib_deps = 
-    ${core-esp32-s3.lib_deps}
-	iavorvel/MyLD2410 @ ~1.0.12
-	https://github.com/pololu/apa102-arduino
 
 [env:Waveshare-ESP32-S3-LCD-1_47]
 extends = core-esp32-s3


### PR DESCRIPTION
I'm assuming the version of LILYGO-T-Dongle-S3 without the screen that I got is the same as the regular one minus the screen, so I modified the platformio.ini adding the no-screen version, basically copy-pasted the block for the regular one with added `-D NO_TFT` and removed `DISPLAY` related lines. Flashing the original `LILYGO-T-Dongle-S3` entry sent the device into a reboot loop, the new entry works as expected.